### PR TITLE
Add source and content licenses

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,19 @@
 # Minigames
 
 This project is used to develop small projects where we build game mechanics around one or more educational concepts. Each project should define the educational purpose and describe the way certain game mechanics help the learner to explore those concepts.
+
+## Licenses
+
+### Game art
+
+<a rel="license" href="http://creativecommons.org/licenses/by-sa/4.0/"><img alt="Creative Commons License" style="border-width:0" src="https://i.creativecommons.org/l/by-sa/4.0/88x31.png" /></a><br />All media assets in this project, such as game art and text, are licensed under a <a rel="license" href="http://creativecommons.org/licenses/by-sa/4.0/">Creative Commons Attribution-ShareAlike 4.0 International License</a>, either version 4 of the License, or (at your option) any later version.
+
+### Source code
+
+<a rel="license" href="https://www.gnu.org/licenses/agpl-3.0.html"><img alt="GNU Affero General Public License" style="border-width:0" src="https://www.gnu.org/graphics/agplv3-155x51.png" /></a>
+
+This program is free software: you can redistribute it and/or modify it under the terms of the [GNU Affero General Public License](https://www.gnu.org/licenses/agpl-3.0.html) as published by the Free Software Foundation, either version 3 of the License, or (at your option) any later version.
+
+This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU Affero General Public License for more details.
+
+You should have received a copy of the GNU Affero General Public License along with this program. If not, see <https://www.gnu.org/licenses/>.


### PR DESCRIPTION
Changes
- add a section describing the Creative Commons - Attribution - Share Alike license as it applies to game art in this project
- add a section describing the GNU Affero General Public License as it applies to source code in this project

Note: I added the GNU AGPL since this software may have components that run on a server computer in addition to personal devices, for which the GNU AGPL is better suited.

Signed-off-by: Brylie Christopher Oxley <brylie@amble.fi>